### PR TITLE
Build OTIO for Android and add GitHub Actions workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -43,6 +43,22 @@ jobs:
         name: Package-${{ matrix.os }}
         path: build/natives/bin/Release
 
+  android:
+    name: Build for android
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install NDK and CMake
+        shell: bash
+        run: $ANDROID_HOME/tools/bin/sdkmanager "ndk;22.0.7026061" "cmake;3.10.2.4988404"
+      - name: Build
+        shell: bash
+        run: ./gradlew build -x test -PandroidBuild -Psdk_path=$ANDROID_HOME
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: Android-JAR
+          path: build/libs
+  
   combine:
     name: Download platform-specific binaries and combine into single JAR
     needs: [build]

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Install NDK and CMake
         shell: bash
         run: $ANDROID_HOME/tools/bin/sdkmanager "ndk;22.0.7026061" "cmake;3.10.2.4988404"
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
       - name: Build
         shell: bash
         run: ./gradlew build -x test -PandroidBuild -Psdk_path=$ANDROID_HOME

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "deps/OpenTimelineIO"]
-	path = deps/OpenTimelineIO
-	url = https://github.com/PixarAnimationStudios/OpenTimelineIO
-	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/OpenTimelineIO"]
+	path = deps/OpenTimelineIO
+	url = https://github.com/PixarAnimationStudios/OpenTimelineIO

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,14 @@ if(NOT CMAKE_BUILD_TYPE)
       FORCE)
 endif()
 
+set(OTIO_PYTHON_INSTALL OFF CACHE BOOL "")
+set(OTIO_CXX_INSTALL OFF CACHE BOOL "")
+set(OTIO_DEPENDENCIES_INSTALL OFF CACHE BOOL "")
+set(OTIO_INSTALL_COMMANDLINE_TOOLS OFF CACHE BOOL "")
+set(OTIO_SHARED_LIBS ON)
+
+set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+
 include_directories(src/main/include)
 add_subdirectory(deps/OpenTimelineIO build/natives)
 add_subdirectory(src/main/cpp)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,70 @@ gradle build # this builds and runs all tests
 
 You can find the generated jar file in the `build/libs` directory.
 
+Building OpenTimelineIO-Java-Bindings for Android
+------------------------
+
+This has been built and tested on Ubuntu 18.04LTS.
+
+Install Android Studio according to these [steps](https://developer.android.com/studio).
+
+Install NDK and CMake using [sdkmanager](https://developer.android.com/studio/command-line/sdkmanager) as follows:
+
+`sdkmanager "ndk;22.0.7026061" "cmake;3.10.2.4988404"`
+
+You can find `sdkmanager` in `$ANDROID_HOME/tools/bin/`. `$ANDROID_HOME` is the location of Android SDK which is generally `~/Android/Sdk`.
+
+Set the `ANDROID_HOME` environment variable and from the root directory of the project run:
+
+```console
+gradle clean
+gradle build -x test -PandroidBuild -Psdk_path=$ANDROID_HOME
+```
+
+You'll find the JAR in `build/libs`
+
+#### How to include the Android JAR in your project
+
+Copy the JAR to the `libs` directory and add this to the app level `build.gradle`:
+
+```groovy
+android {
+    ...
+    
+    ndkVersion '22.0.7026061'
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    ...
+}
+
+task unjar {
+    ant.unzip(src: 'libs/java-opentimelineio-0.14.0.jar', dest: 'JARUnzip')
+
+    copy {
+        from 'JARUnzip/arm64-v8a'
+        into 'src/main/jniLibs/arm64-v8a'
+    }
+    copy {
+        from 'JARUnzip/x86_64'
+        into 'src/main/jniLibs/x86_64'
+    }
+}
+
+build.dependsOn unjar
+
+dependencies {
+    ...
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation files('libs/java-opentimelineio-0.14.0.jar')
+    ...
+}
+
+```
+
+
 Examples
 --------
 

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ task compileJNI {
 //                            'mv lib/Release/Android/ lib/Release/x86_64'
                     commandLine 'sh', '-c', 'mkdir -p build/natives && ' +
                             'cd build/natives && ' +
-                            'cmake -G"Ninja" -DANDROID_ABI=armeabi-v7a -DANDROID_NDK='+sdk_path+'/ndk/22.0.7026061 -DCMAKE_BUILD_TYPE=Release -DCMAKE_MAKE_PROGRAM='+sdk_path+'/cmake/3.10.2.4988404/bin/ninja -DCMAKE_TOOLCHAIN_FILE='+sdk_path+'/ndk/22.0.7026061/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=23 -DANDROID_TOOLCHAIN=clang ../.. && ' +
+                            'cmake -G"Ninja" -DANDROID_ABI=arm64-v8a -DANDROID_NDK='+sdk_path+'/ndk/22.0.7026061 -DCMAKE_BUILD_TYPE=Release -DCMAKE_MAKE_PROGRAM='+sdk_path+'/cmake/3.10.2.4988404/bin/ninja -DCMAKE_TOOLCHAIN_FILE='+sdk_path+'/ndk/22.0.7026061/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=23 -DANDROID_TOOLCHAIN=clang ../.. && ' +
                             'cmake --build . --config Release && ' +
                             'mv lib/Release/Android/ lib/Release/arm64-v8a && ' +
                             'rm CMakeCache.txt && ' +

--- a/build.gradle
+++ b/build.gradle
@@ -68,15 +68,6 @@ task compileJNI {
                     OperatingSystem.current().isUnix()) {
                 if (project.hasProperty("androidBuild") && project.hasProperty("sdk_path")){
                     def sdk_path = project.getProperties().getAt('sdk_path').toString()
-//                    commandLine 'sh', '-c', 'mkdir -p build/natives && ' +
-//                            'cd build/natives && ' +
-//                            '/home/karthik/Android/Sdk/cmake/3.10.2.4988404/bin/cmake -G"Ninja" -DANDROID_ABI=arm64-v8a -DANDROID_NDK=/home/karthik/Android/Sdk/ndk/22.0.7026061 -DCMAKE_BUILD_TYPE=Release -DCMAKE_MAKE_PROGRAM=/home/karthik/Android/Sdk/cmake/3.10.2.4988404/bin/ninja -DCMAKE_TOOLCHAIN_FILE=/home/karthik/Android/Sdk/ndk/22.0.7026061/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=23 -DANDROID_TOOLCHAIN=clang ../.. && ' +
-//                            'cmake --build . --config Release && ' +
-//                            'mv lib/Release/Android/ lib/Release/arm64-v8a && ' +
-//                            'rm CMakeCache.txt && ' +
-//                            '/home/karthik/Android/Sdk/cmake/3.10.2.4988404/bin/cmake -G"Ninja" -DANDROID_ABI=x86_64 -DANDROID_NDK=/home/karthik/Android/Sdk/ndk/22.0.7026061 -DCMAKE_BUILD_TYPE=Release -DCMAKE_MAKE_PROGRAM=/home/karthik/Android/Sdk/cmake/3.10.2.4988404/bin/ninja -DCMAKE_TOOLCHAIN_FILE=/home/karthik/Android/Sdk/ndk/22.0.7026061/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=23 -DANDROID_TOOLCHAIN=clang ../.. && ' +
-//                            'cmake --build . --config Release && ' +
-//                            'mv lib/Release/Android/ lib/Release/x86_64'
                     commandLine 'sh', '-c', 'mkdir -p build/natives && ' +
                             'cd build/natives && ' +
                             'cmake -G"Ninja" -DANDROID_ABI=arm64-v8a -DANDROID_NDK='+sdk_path+'/ndk/22.0.7026061 -DCMAKE_BUILD_TYPE=Release -DCMAKE_MAKE_PROGRAM='+sdk_path+'/cmake/3.10.2.4988404/bin/ninja -DCMAKE_TOOLCHAIN_FILE='+sdk_path+'/ndk/22.0.7026061/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=23 -DANDROID_TOOLCHAIN=clang ../.. && ' +
@@ -90,7 +81,6 @@ task compileJNI {
                 else {
                     commandLine 'sh', '-c', 'mkdir -p build/natives && cd build/natives && cmake ../.. && cmake --build . --config Release'
                 }
-//                commandLine 'sh', '-c', 'mkdir -p build/natives && cd build/natives && cmake ../.. && cmake --build . --config Release'
             } else if (OperatingSystem.current().isWindows()) {
                 commandLine "cmd", "/c", 'if not exist "build\\natives" mkdir build\\natives && cd build\\natives && cmake ..\\.. && cmake --build . --config Release'
             }

--- a/build.gradle
+++ b/build.gradle
@@ -79,11 +79,11 @@ task compileJNI {
 //                            'mv lib/Release/Android/ lib/Release/x86_64'
                     commandLine 'sh', '-c', 'mkdir -p build/natives && ' +
                             'cd build/natives && ' +
-                            sdk_path +'/cmake/3.10.2.4988404/bin/cmake -G"Ninja" -DANDROID_ABI=arm64-v8a -DANDROID_NDK='+sdk_path+'/ndk/22.0.7026061 -DCMAKE_BUILD_TYPE=Release -DCMAKE_MAKE_PROGRAM='+sdk_path+'/cmake/3.10.2.4988404/bin/ninja -DCMAKE_TOOLCHAIN_FILE='+sdk_path+'/ndk/22.0.7026061/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=23 -DANDROID_TOOLCHAIN=clang ../.. && ' +
+                            'cmake -G"Ninja" -DANDROID_ABI=armeabi-v7a -DANDROID_NDK='+sdk_path+'/ndk/22.0.7026061 -DCMAKE_BUILD_TYPE=Release -DCMAKE_MAKE_PROGRAM='+sdk_path+'/cmake/3.10.2.4988404/bin/ninja -DCMAKE_TOOLCHAIN_FILE='+sdk_path+'/ndk/22.0.7026061/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=23 -DANDROID_TOOLCHAIN=clang ../.. && ' +
                             'cmake --build . --config Release && ' +
                             'mv lib/Release/Android/ lib/Release/arm64-v8a && ' +
                             'rm CMakeCache.txt && ' +
-                            sdk_path +'/cmake/3.10.2.4988404/bin/cmake -G"Ninja" -DANDROID_ABI=x86_64 -DANDROID_NDK='+sdk_path+'/ndk/22.0.7026061 -DCMAKE_BUILD_TYPE=Release -DCMAKE_MAKE_PROGRAM='+sdk_path+'/cmake/3.10.2.4988404/bin/ninja -DCMAKE_TOOLCHAIN_FILE='+sdk_path+'/ndk/22.0.7026061/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=23 -DANDROID_TOOLCHAIN=clang ../.. && ' +
+                            'cmake -G"Ninja" -DANDROID_ABI=x86_64 -DANDROID_NDK='+sdk_path+'/ndk/22.0.7026061 -DCMAKE_BUILD_TYPE=Release -DCMAKE_MAKE_PROGRAM='+sdk_path+'/cmake/3.10.2.4988404/bin/ninja -DCMAKE_TOOLCHAIN_FILE='+sdk_path+'/ndk/22.0.7026061/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=23 -DANDROID_TOOLCHAIN=clang ../.. && ' +
                             'cmake --build . --config Release && ' +
                             'mv lib/Release/Android/ lib/Release/x86_64'
                 }

--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -42,7 +42,9 @@ add_library(jotio SHARED
         io_opentimeline_opentimelineio_OTIOTest.cpp)
 
 target_include_directories(jotio PUBLIC
-        "${PROJECT_SOURCE_DIR}/../")
+        "${PROJECT_SOURCE_DIR}/deps/OpenTimelineIO/src"
+        "${PROJECT_SOURCE_DIR}/deps/OpenTimelineIO/src/deps"
+        "${PROJECT_SOURCE_DIR}/deps/OpenTimelineIO/src/deps/optional-lite/include")
 
 target_link_libraries(jotio opentime)
 target_link_libraries(jotio opentimelineio)

--- a/src/main/java/io/opentimeline/LibraryLoader.java
+++ b/src/main/java/io/opentimeline/LibraryLoader.java
@@ -29,7 +29,6 @@ public class LibraryLoader {
     public static void load(String name) {
         if (libLoaded)
             return;
-//        name += ("-" + OTIO_VERSION);
         final String libname = System.mapLibraryName(name);
         final String opentimelibname = System.mapLibraryName("opentime");
         final String OTIOlibname = System.mapLibraryName("opentimelineio");

--- a/src/main/java/io/opentimeline/NativeUtils.java
+++ b/src/main/java/io/opentimeline/NativeUtils.java
@@ -99,11 +99,9 @@ public class NativeUtils {
         try (InputStream is = NativeUtils.class.getResourceAsStream(path)) {
             Files.copy(is, temp.toPath(), StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
-            System.out.println("here1");
             temp.delete();
             throw e;
         } catch (NullPointerException e) {
-            System.out.println("here2: " + path);
             temp.delete();
             throw new FileNotFoundException("File " + path + " was not found inside JAR.");
         }


### PR DESCRIPTION
This PR adds code to build the lib for 64-bit Android.

We need to disable building of pybind11. The option to do that was added in a more recent commit to OTIO. But the minimum cmake version was also bumped up. The Android cmake toolchain is max 3.10.