### PR TITLE
Build for 32-bit android

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,15 @@ task compileJNI {
                             'rm CMakeCache.txt && ' +
                             'cmake -G"Ninja" -DANDROID_ABI=x86_64 -DANDROID_NDK='+sdk_path+'/ndk/22.0.7026061 -DCMAKE_BUILD_TYPE=Release -DCMAKE_MAKE_PROGRAM='+sdk_path+'/cmake/3.10.2.4988404/bin/ninja -DCMAKE_TOOLCHAIN_FILE='+sdk_path+'/ndk/22.0.7026061/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=23 -DANDROID_TOOLCHAIN=clang ../.. && ' +
                             'cmake --build . --config Release && ' +
-                            'mv lib/Release/Android/ lib/Release/x86_64'
+                            'mv lib/Release/Android/ lib/Release/x86_64 && ' +
+                            'rm CMakeCache.txt && ' +
+                            'cmake -G"Ninja" -DANDROID_ABI=armeabi-v7a -DANDROID_NDK='+sdk_path+'/ndk/22.0.7026061 -DCMAKE_BUILD_TYPE=Release -DCMAKE_MAKE_PROGRAM='+sdk_path+'/cmake/3.10.2.4988404/bin/ninja -DCMAKE_TOOLCHAIN_FILE='+sdk_path+'/ndk/22.0.7026061/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=23 -DANDROID_TOOLCHAIN=clang ../.. && ' +
+                            'cmake --build . --config Release && ' +
+                            'mv lib/Release/Android/ lib/Release/armeabi-v7a && ' +
+                            'rm CMakeCache.txt && ' +
+                            'cmake -G"Ninja" -DANDROID_ABI=x86 -DANDROID_NDK='+sdk_path+'/ndk/22.0.7026061 -DCMAKE_BUILD_TYPE=Release -DCMAKE_MAKE_PROGRAM='+sdk_path+'/cmake/3.10.2.4988404/bin/ninja -DCMAKE_TOOLCHAIN_FILE='+sdk_path+'/ndk/22.0.7026061/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=23 -DANDROID_TOOLCHAIN=clang ../.. && ' +
+                            'cmake --build . --config Release && ' +
+                            'mv lib/Release/Android/ lib/Release/x86'
                 }
                 else {
                     commandLine 'sh', '-c', 'mkdir -p build/natives && cd build/natives && cmake ../.. && cmake --build . --config Release'


### PR DESCRIPTION
This PR adds commands to build for armeabi-v7a and x86 architectures.

Once [927](https://github.com/PixarAnimationStudios/OpenTimelineIO/pull/927) is merged, we need to update the OTIO submodule and this PR can be merged then.