### PR TITLE
Build system tweaks

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -25,7 +25,7 @@ jobs:
         run: $ANDROID_HOME/tools/bin/sdkmanager "ndk;22.0.7026061" "cmake;3.10.2.4988404"
       - name: Build
         shell: bash
-        run: ./gradlew build -x test -PandroidBuild -Psdk_path=$ANDROID_HOME
+        run: ./gradlew build -x test -PandroidBuild -PandroidSDKPath=$ANDROID_HOME
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -69,9 +69,9 @@ jobs:
           fi
         fi
         if [ $OS = "windows-latest" ] && ([ $ARCHITECTURE = "aarch32" ] || [ $ARCHITECTURE = "aarch64" ]); then
-          ./gradlew build -P${ARCHITECTURE}Build -ParmJdkPath=${armJdkPath} -x test
+          ./gradlew build -P${ARCHITECTURE}Build -ParmJdkPath=${armJdkPath} -Pj=2 -x test
         else
-          ./gradlew build -P${ARCHITECTURE}Build -ParmJdkPath=${armJdkPath}
+          ./gradlew build -P${ARCHITECTURE}Build -ParmJdkPath=${armJdkPath} -Pj=2
         fi
     - name: Upload artifact
       if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'

--- a/README.md
+++ b/README.md
@@ -68,8 +68,10 @@ git clone --recurse-submodules https://github.com/OpenTimelineIO/OpenTimelineIO-
 
 cd OpenTimelineIO-Java-Bindings
 
-./gradlew build # this builds and runs all tests
+./gradlew build -Pj=<number of parallel jobs># this builds and runs all tests
 ```
+The optional property `-Pj` specifies the parallel build level for the C++/JNI code.
+
 If you're using a system-wide gradle installation, ensure the version to be 6.x.x.
 You can find the generated jar file in the `build/libs` directory.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Set the `ANDROID_HOME` environment variable and from the root directory of the p
 
 ```shell
 gradle clean
-gradle build -x test -PandroidBuild -Psdk_path=$ANDROID_HOME
+gradle build -x test -PandroidBuild -PandroidSDKPath=$ANDROID_HOME
 ```
 
 You'll find the JAR in `build/libs`

--- a/build.gradle
+++ b/build.gradle
@@ -189,12 +189,14 @@ task compileJNI {
 
 def renamePlatformArtifactsDirectoryAccordingToArchitecture(File nativeDir, String architecture) {
     def platformArtifactsDirectoryPath = ""
+    def artifactsDirectoryPath = "lib/Release/"
+
+    // determine path for directory created after cmake build, eg: build/natives/lib/Release/Linux
     if (OperatingSystem.current().isLinux()) {
-        platformArtifactsDirectoryPath = "lib/Release/"
         if (project.hasProperty("androidBuild") && project.hasProperty("sdk_path")) {
-            platformArtifactsDirectoryPath = platformArtifactsDirectoryPath + "Android"
+            platformArtifactsDirectoryPath = artifactsDirectoryPath + "Android"
         } else {
-            platformArtifactsDirectoryPath = platformArtifactsDirectoryPath + "Linux"
+            platformArtifactsDirectoryPath = artifactsDirectoryPath + "Linux"
         }
     } else if (OperatingSystem.current().isWindows()) {
         platformArtifactsDirectoryPath = "bin/Release/Windows"
@@ -202,16 +204,27 @@ def renamePlatformArtifactsDirectoryAccordingToArchitecture(File nativeDir, Stri
         // do not rename artifacts directory for OSes other than windows & linux
         return
     }
-
     def platformArtifactsDirectory = new File(nativeDir, platformArtifactsDirectoryPath)
 
-    def architectureArtifactsDir = new File(platformArtifactsDirectory.getPath() + "-" + architecture)
-    if (architectureArtifactsDir.exists()) {
-        architectureArtifactsDir.deleteDir()
+    // determine renamed path, including the architecture for the build, eg: build/natives/lib/Release/Linux-amd64
+    def architectureArtifactsDirectoryPath = ""
+    if (OperatingSystem.current().isLinux() && project.hasProperty("androidBuild") && project.hasProperty("sdk_path")) {
+        // naming pattern for android is different, eg:  build/natives/lib/Release/arm64-v8a
+        // so, handle that separately
+        architectureArtifactsDirectoryPath = artifactsDirectoryPath + architecture
+    } else {
+        architectureArtifactsDirectoryPath = platformArtifactsDirectoryPath + "-" + architecture
+    }
+    def architectureArtifactsDirectory = new File(architectureArtifactsDirectoryPath)
+
+    // if build has been rerun, delete the existing artifacts
+    if (architectureArtifactsDirectory.exists()) {
+        architectureArtifactsDirectory.deleteDir()
     }
 
+    // rename the directory created after cmake build to include architecture in the directory name
     if (platformArtifactsDirectory.exists()) {
-        platformArtifactsDirectory.renameTo(architectureArtifactsDir)
+        platformArtifactsDirectory.renameTo(architectureArtifactsDirectory)
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -112,79 +112,105 @@ task compileJNI {
             nativeDir.mkdirs()
         }
 
-        String architecture = "";
-        def androidArchitectures = ["arm64-v8a", "x86_64", "armeabi-v7a", "x86"] as String[]
+        String architecture = ""
 
         // determine CPU architecture name and windows generator name
-        String generator = "";
-        if (System.getProperty("os.arch").equals("arm") || System.getProperty("os.arch").equals("aarch32")
-                || project.hasProperty("aarch32Build")) {
-            architecture = "aarch32";
-            generator = "ARM";
-        } else if (System.getProperty("os.arch").equals("arm64") || System.getProperty("os.arch").equals("aarch64")
-                || project.hasProperty("aarch64Build")) {
-            architecture = "aarch64";
-            generator = "ARM64";
-        } else if (System.getProperty("os.arch").endsWith("86")) {
-            architecture = "x86";
-            generator = "Win32";
-        } else if (System.getProperty("os.arch").equals("amd64") || System.getProperty("os.arch").equals("x86_64")) {
-            architecture = "amd64";
-            generator = "x64";
+        String generator = ""
+        String osArch = System.getProperty("os.arch")
+
+        if (osArch in ["arm", "aarch32"] || project.hasProperty("aarch32Build")) {
+            architecture = "aarch32"
+            generator = "ARM"
+        } else if (osArch in ["arm64", "aarch64"] || project.hasProperty("aarch64Build")) {
+            architecture = "aarch64"
+            generator = "ARM64"
+        } else if (osArch.endsWith("86")) {
+            architecture = "x86"
+            generator = "Win32"
+        } else if (osArch in ["amd64", "x86_64"]) {
+            architecture = "amd64"
+            generator = "x64"
         }
 
         String buildConcurrency = "-j " + Runtime.getRuntime().availableProcessors().toString()
         // this property will not be used for android builds, as android builds use ninja instead of make
         if (project.hasProperty("j")) {
-            buildConcurrency = "-j " + project.getAt('j').toString()
+            buildConcurrency = "-j " + project['j'].toString()
         }
 
-        Map<String, String> architectureCommandsMap = new HashMap<>()
-
-        if (OperatingSystem.current().isLinux() ||
-                OperatingSystem.current().isMacOsX() ||
-                OperatingSystem.current().isUnix()) {
-
-            // ANDROID BUILD
-            if (project.hasProperty("androidBuild") && project.hasProperty("sdk_path")) {
-                def sdk_path = project.getProperties().getAt('sdk_path').toString()
-                for (arch in androidArchitectures) {
-                    def commandStr = 'cmake -G"Ninja" -DANDROID_ABI=' + arch + ' -DANDROID_NDK=' + sdk_path + '/ndk/22.0.7026061 -DCMAKE_BUILD_TYPE=Release -DCMAKE_MAKE_PROGRAM=' + sdk_path + '/cmake/3.10.2.4988404/bin/ninja -DCMAKE_TOOLCHAIN_FILE=' + sdk_path + '/ndk/22.0.7026061/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=23 -DANDROID_TOOLCHAIN=clang ../.. && ' +
-                            'cmake --build . --config Release && ' +
-                            'mv lib/Release/Android/ lib/Release/' + arch + ' && ' +
-                            'rm CMakeCache.txt'
-                    architectureCommandsMap.put(arch, 'cd build/natives && ' + commandStr)
-                }
-            } else if (OperatingSystem.current().isMacOsX()) {
-                architectureCommandsMap.put(architecture, 'cd build/natives && cmake ../.. && cmake --build . --config Release ' + buildConcurrency)
-            } else if (OperatingSystem.current().isLinux()) { // LINUX BUILD
-                def cmakeToolchain = ""
-                if (architecture == "aarch64" || architecture == "aarch32" || architecture == "x86" ||
-                        project.hasProperty("aarch64Build") || project.hasProperty("aarch32Build")) {
-                    cmakeToolchain = "-DCMAKE_TOOLCHAIN_FILE=../../linux-" + architecture + "-toolchain.cmake"
-                } else if (System.getProperty("os.arch") == "x86_64" || System.getProperty("os.arch") == "amd64") {
-                    cmakeToolchain = ""
-                }
-                architectureCommandsMap.put(architecture, 'cd build/natives && cmake ../.. ' + cmakeToolchain + ' && cmake --build . --config Release ' + buildConcurrency)
-            }
+        // ANDROID BUILD
+        if (OperatingSystem.current().isLinux() &&
+                (project.hasProperty("androidBuild") && project.hasProperty("androidSDKPath"))) {
+            invokeAndroidBuild(nativeDir)
+        } else if (OperatingSystem.current().isMacOsX()) {
+            invokeMacOSBuild(nativeDir, architecture, buildConcurrency)
+        } else if (OperatingSystem.current().isLinux()) { // LINUX BUILD
+            invokeLinuxBuild(nativeDir, architecture, buildConcurrency)
         } else if (OperatingSystem.current().isWindows()) { // WINDOWS BUILD
-            architectureCommandsMap.put(architecture, 'cd build\\natives && cmake -A ' + generator + ' ..\\.. && cmake --build . --config Release')
+            invokeWindowsBuild(nativeDir, architecture, buildConcurrency, generator)
+        } else {
+            throw new GradleException(String.format("Operating System not supported: %s", OperatingSystem.current().getName()))
         }
-
-        architectureCommandsMap.each {arch, command ->
-            exec {
-                if (OperatingSystem.current().isLinux() ||
-                        OperatingSystem.current().isMacOsX() ||
-                        OperatingSystem.current().isUnix()) {
-                    commandLine 'sh', '-c', command
-                } else if (OperatingSystem.current().isWindows()) {
-                    commandLine "cmd", "/c", command
-                }
-            }
-            renamePlatformArtifactsDirectoryAccordingToArchitecture(nativeDir, arch)
-        }
-
     }
+}
+
+def invokeAndroidBuild(File nativeDir) {
+    def androidArchitectures = ["arm64-v8a", "x86_64", "armeabi-v7a", "x86"] as String[]
+    def androidSDKPath = project.getProperties()['androidSDKPath'].toString()
+
+    logger.info(String.format("Executing Android build. Architectures: %s", Arrays.toString(androidArchitectures)))
+
+    for (arch in androidArchitectures) {
+        exec {
+            commandLine 'cmake', '-B' + nativeDir.getPath(), '-S.', '-GNinja', '-DANDROID_ABI=' + arch, '-DANDROID_NDK=' + androidSDKPath + '/ndk/22.0.7026061', '-DCMAKE_BUILD_TYPE=Release', '-DCMAKE_MAKE_PROGRAM=' + androidSDKPath + '/cmake/3.10.2.4988404/bin/ninja', '-DCMAKE_TOOLCHAIN_FILE=' + androidSDKPath + '/ndk/22.0.7026061/build/cmake/android.toolchain.cmake', '-DANDROID_NATIVE_API_LEVEL=23', '-DANDROID_TOOLCHAIN=clang'
+        }
+        exec {
+            commandLine 'cmake', '--build', nativeDir.getPath(), '--config', 'Release'
+        }
+        exec {
+            commandLine 'rm', nativeDir.getPath() + '/CMakeCache.txt'
+        }
+        renamePlatformArtifactsDirectoryAccordingToArchitecture(nativeDir, arch)
+    }
+}
+
+def invokeMacOSBuild(File nativeDir, String architecture, String buildConcurrency) {
+    logger.info(String.format("Executing macOS build. Architecture: %s", architecture))
+    exec {
+        commandLine 'cmake', '-B' + nativeDir.getPath(), '-S.'
+    }
+    exec {
+        commandLine 'cmake', '--build', nativeDir.getPath(), '--config', 'Release', buildConcurrency
+    }
+    renamePlatformArtifactsDirectoryAccordingToArchitecture(nativeDir, architecture)
+}
+
+def invokeLinuxBuild(File nativeDir, String architecture, String buildConcurrency) {
+    logger.info(String.format("Executing Linux build. Architecture: %s", architecture))
+    def isARMBuild = architecture == "aarch64" || architecture == "aarch32" || architecture == "x86" ||
+            project.hasProperty("aarch64Build") || project.hasProperty("aarch32Build")
+    def cmakeToolchain = ""
+    if (isARMBuild) {
+        cmakeToolchain = "-DCMAKE_TOOLCHAIN_FILE=./linux-" + architecture + "-toolchain.cmake"
+    }
+    exec {
+        commandLine 'cmake', '-B' + nativeDir.getPath(), '-S.', cmakeToolchain
+    }
+    exec {
+        commandLine 'cmake', '--build', nativeDir.getPath(), '--config', 'Release', buildConcurrency
+    }
+    renamePlatformArtifactsDirectoryAccordingToArchitecture(nativeDir, architecture)
+}
+
+def invokeWindowsBuild(File nativeDir, String architecture, String generator, String buildConcurrency) {
+    logger.info(String.format("Executing Windows build. Architecture: %s", architecture))
+    exec {
+        commandLine 'cmake', '-B' + nativeDir.getPath(), '-S.', '-A', generator
+    }
+    exec {
+        commandLine 'cmake', '--build', nativeDir.getPath(), '--config', 'Release', buildConcurrency
+    }
+    renamePlatformArtifactsDirectoryAccordingToArchitecture(nativeDir, architecture)
 }
 
 def renamePlatformArtifactsDirectoryAccordingToArchitecture(File nativeDir, String architecture) {
@@ -193,7 +219,7 @@ def renamePlatformArtifactsDirectoryAccordingToArchitecture(File nativeDir, Stri
 
     // determine path for directory created after cmake build, eg: build/natives/lib/Release/Linux
     if (OperatingSystem.current().isLinux()) {
-        if (project.hasProperty("androidBuild") && project.hasProperty("sdk_path")) {
+        if (project.hasProperty("androidBuild") && project.hasProperty("androidSDKPath")) {
             platformArtifactsDirectoryPath = artifactsDirectoryPath + "Android"
         } else {
             platformArtifactsDirectoryPath = artifactsDirectoryPath + "Linux"
@@ -205,17 +231,18 @@ def renamePlatformArtifactsDirectoryAccordingToArchitecture(File nativeDir, Stri
         return
     }
     def platformArtifactsDirectory = new File(nativeDir, platformArtifactsDirectoryPath)
+    System.out.println(platformArtifactsDirectory.getPath())
 
     // determine renamed path, including the architecture for the build, eg: build/natives/lib/Release/Linux-amd64
     def architectureArtifactsDirectoryPath = ""
-    if (OperatingSystem.current().isLinux() && project.hasProperty("androidBuild") && project.hasProperty("sdk_path")) {
+    if (OperatingSystem.current().isLinux() && project.hasProperty("androidBuild") && project.hasProperty("androidSDKPath")) {
         // naming pattern for android is different, eg:  build/natives/lib/Release/arm64-v8a
         // so, handle that separately
         architectureArtifactsDirectoryPath = artifactsDirectoryPath + architecture
     } else {
         architectureArtifactsDirectoryPath = platformArtifactsDirectoryPath + "-" + architecture
     }
-    def architectureArtifactsDirectory = new File(architectureArtifactsDirectoryPath)
+    def architectureArtifactsDirectory = new File(nativeDir, architectureArtifactsDirectoryPath)
 
     // if build has been rerun, delete the existing artifacts
     if (architectureArtifactsDirectory.exists()) {

--- a/build.gradle
+++ b/build.gradle
@@ -120,6 +120,12 @@ task compileJNI {
                 generator = "x64";
             }
 
+            String buildConcurrency = ""
+            // this property will not be used for android builds, as android builds use ninja instead of make
+            if (project.hasProperty("j")) {
+                buildConcurrency = "-j " + project.getAt('j').toString()
+            }
+
             if (OperatingSystem.current().isLinux() ||
                     OperatingSystem.current().isMacOsX() ||
                     OperatingSystem.current().isUnix()) {
@@ -140,7 +146,7 @@ task compileJNI {
                             'cd build/natives && ' +
                             buildCommand
                 } else if (OperatingSystem.current().isMacOsX()) {
-                    commandLine 'sh', '-c', 'mkdir -p build/natives && cd build/natives && cmake ../.. && cmake --build . --config Release'
+                    commandLine 'sh', '-c', 'mkdir -p build/natives && cd build/natives && cmake ../.. && cmake --build . --config Release ' + buildConcurrency
                 } else if (OperatingSystem.current().isLinux()) { // LINUX BUILD
                     def nativeDir = new File('build/natives')
                     if (!nativeDir.exists()) {
@@ -153,15 +159,15 @@ task compileJNI {
                     } else if (System.getProperty("os.arch") == "x86_64" || System.getProperty("os.arch") == "amd64") {
                         cmakeToolchain = "&&"
                     }
-                    commandLine 'sh', '-c', 'cd build/natives && cmake ../.. ' + cmakeToolchain + ' cmake --build . --config Release && ' +
-                            'mv lib/Release/Linux lib/Release/Linux-' + architecture
+                    commandLine 'sh', '-c', 'cd build/natives && cmake ../.. ' + cmakeToolchain + ' cmake --build . --config Release ' + buildConcurrency + ' && ' +
+                            'if [ -d "lib/Release/Linux-' + architecture + '" ]; then rm -rf lib/Release/Linux-' + architecture + '; fi && mv lib/Release/Linux lib/Release/Linux-' + architecture
                 }
             } else if (OperatingSystem.current().isWindows()) { // WINDOWS BUILD
                 def nativeDir = new File('build\\natives')
                 if (!nativeDir.exists()) {
                     nativeDir.mkdirs()
                 }
-                commandLine "cmd", "/c", 'cd build\\natives && cmake -A ' + generator + ' ..\\.. && cmake --build . --config Release && ' +
+                commandLine "cmd", "/c", 'cd build\\natives && cmake -A ' + generator + ' ..\\.. && cmake --build . --config Release ' + buildConcurrency + ' && ' +
                         'ren bin\\Release\\Windows Windows-' + architecture
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -138,14 +138,16 @@ task compileJNI {
             buildConcurrency = "-j " + project['j'].toString()
         }
 
-        // ANDROID BUILD
-        if (OperatingSystem.current().isLinux() &&
-                (project.hasProperty("androidBuild") && project.hasProperty("androidSDKPath"))) {
-            invokeAndroidBuild(nativeDir)
-        } else if (OperatingSystem.current().isMacOsX()) {
+        if (OperatingSystem.current().isLinux()) {
+            if (project.hasProperty("androidBuild") && project.hasProperty("androidSDKPath")) {
+                invokeAndroidBuild(nativeDir) // ANDROID BUILD
+            } else if (project.hasProperty("androidBuild") || project.hasProperty("androidSDKPath")) {
+                throw new GradleException("Both properties, androidBuild and androidSDKPath need to be defined.")
+            } else { // LINUX BUILD
+                invokeLinuxBuild(nativeDir, architecture, buildConcurrency)
+            }
+        } else if (OperatingSystem.current().isMacOsX()) { // MAC OS BUILD
             invokeMacOSBuild(nativeDir, architecture, buildConcurrency)
-        } else if (OperatingSystem.current().isLinux()) { // LINUX BUILD
-            invokeLinuxBuild(nativeDir, architecture, buildConcurrency)
         } else if (OperatingSystem.current().isWindows()) { // WINDOWS BUILD
             invokeWindowsBuild(nativeDir, architecture, generator, buildConcurrency)
         } else {

--- a/build.gradle
+++ b/build.gradle
@@ -100,77 +100,109 @@ task compileJNI {
     dependsOn compileJava
     outputs.upToDateWhen { false }
     doLast {
-        exec {
-            // determine CPU architecture name and windows generator name
-            String architecture = "";
-            String generator = "";
-            if (System.getProperty("os.arch").equals("arm") || System.getProperty("os.arch").equals("aarch32")
-                    || project.hasProperty("aarch32Build")) {
-                architecture = "aarch32";
-                generator = "ARM";
-            } else if (System.getProperty("os.arch").equals("arm64") || System.getProperty("os.arch").equals("aarch64")
-                    || project.hasProperty("aarch64Build")) {
-                architecture = "aarch64";
-                generator = "ARM64";
-            } else if (System.getProperty("os.arch").endsWith("86")) {
-                architecture = "x86";
-                generator = "Win32";
-            } else if (System.getProperty("os.arch").equals("amd64") || System.getProperty("os.arch").equals("x86_64")) {
-                architecture = "amd64";
-                generator = "x64";
-            }
 
-            String buildConcurrency = ""
-            // this property will not be used for android builds, as android builds use ninja instead of make
-            if (project.hasProperty("j")) {
-                buildConcurrency = "-j " + project.getAt('j').toString()
-            }
-
-            if (OperatingSystem.current().isLinux() ||
-                    OperatingSystem.current().isMacOsX() ||
-                    OperatingSystem.current().isUnix()) {
-                // ANDROID BUILD
-                if (project.hasProperty("androidBuild") && project.hasProperty("sdk_path")) {
-                    def sdk_path = project.getProperties().getAt('sdk_path').toString()
-                    def architectures = ["arm64-v8a", "x86_64", "armeabi-v7a", "x86"] as String[]
-                    def commands = []
-                    for (arch in architectures) {
-                        def commandStr = 'cmake -G"Ninja" -DANDROID_ABI=' + arch + ' -DANDROID_NDK=' + sdk_path + '/ndk/22.0.7026061 -DCMAKE_BUILD_TYPE=Release -DCMAKE_MAKE_PROGRAM=' + sdk_path + '/cmake/3.10.2.4988404/bin/ninja -DCMAKE_TOOLCHAIN_FILE=' + sdk_path + '/ndk/22.0.7026061/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=23 -DANDROID_TOOLCHAIN=clang ../.. && ' +
-                                'cmake --build . --config Release && ' +
-                                'mv lib/Release/Android/ lib/Release/' + arch + ' && ' +
-                                'rm CMakeCache.txt'
-                        commands.add(commandStr)
-                    }
-                    def buildCommand = commands.join(' && ')
-                    commandLine 'sh', '-c', 'mkdir -p build/natives && ' +
-                            'cd build/natives && ' +
-                            buildCommand
-                } else if (OperatingSystem.current().isMacOsX()) {
-                    commandLine 'sh', '-c', 'mkdir -p build/natives && cd build/natives && cmake ../.. && cmake --build . --config Release ' + buildConcurrency
-                } else if (OperatingSystem.current().isLinux()) { // LINUX BUILD
-                    def nativeDir = new File('build/natives')
-                    if (!nativeDir.exists()) {
-                        nativeDir.mkdirs()
-                    }
-                    def cmakeToolchain = ""
-                    if (architecture == "aarch64" || architecture == "aarch32" || architecture == "x86" ||
-                            project.hasProperty("aarch64Build") || project.hasProperty("aarch32Build")) {
-                        cmakeToolchain = "-DCMAKE_TOOLCHAIN_FILE=../../linux-" + architecture + "-toolchain.cmake &&"
-                    } else if (System.getProperty("os.arch") == "x86_64" || System.getProperty("os.arch") == "amd64") {
-                        cmakeToolchain = "&&"
-                    }
-                    commandLine 'sh', '-c', 'cd build/natives && cmake ../.. ' + cmakeToolchain + ' cmake --build . --config Release ' + buildConcurrency + ' && ' +
-                            'if [ -d "lib/Release/Linux-' + architecture + '" ]; then rm -rf lib/Release/Linux-' + architecture + '; fi && mv lib/Release/Linux lib/Release/Linux-' + architecture
-                }
-            } else if (OperatingSystem.current().isWindows()) { // WINDOWS BUILD
-                def nativeDir = new File('build\\natives')
-                if (!nativeDir.exists()) {
-                    nativeDir.mkdirs()
-                }
-                commandLine "cmd", "/c", 'cd build\\natives && cmake -A ' + generator + ' ..\\.. && cmake --build . --config Release ' + buildConcurrency + ' && ' +
-                        'ren bin\\Release\\Windows Windows-' + architecture
-            }
+        def nativeDir = new File('build/natives')
+        if (!nativeDir.exists()) {
+            nativeDir.mkdirs()
         }
+
+        String architecture = "";
+        def androidArchitectures = ["arm64-v8a", "x86_64", "armeabi-v7a", "x86"] as String[]
+
+        // determine CPU architecture name and windows generator name
+        String generator = "";
+        if (System.getProperty("os.arch").equals("arm") || System.getProperty("os.arch").equals("aarch32")
+                || project.hasProperty("aarch32Build")) {
+            architecture = "aarch32";
+            generator = "ARM";
+        } else if (System.getProperty("os.arch").equals("arm64") || System.getProperty("os.arch").equals("aarch64")
+                || project.hasProperty("aarch64Build")) {
+            architecture = "aarch64";
+            generator = "ARM64";
+        } else if (System.getProperty("os.arch").endsWith("86")) {
+            architecture = "x86";
+            generator = "Win32";
+        } else if (System.getProperty("os.arch").equals("amd64") || System.getProperty("os.arch").equals("x86_64")) {
+            architecture = "amd64";
+            generator = "x64";
+        }
+
+        String buildConcurrency = "-j " + Runtime.getRuntime().availableProcessors().toString()
+        // this property will not be used for android builds, as android builds use ninja instead of make
+        if (project.hasProperty("j")) {
+            buildConcurrency = "-j " + project.getAt('j').toString()
+        }
+
+        Map<String, String> architectureCommandsMap = new HashMap<>()
+
+        if (OperatingSystem.current().isLinux() ||
+                OperatingSystem.current().isMacOsX() ||
+                OperatingSystem.current().isUnix()) {
+
+            // ANDROID BUILD
+            if (project.hasProperty("androidBuild") && project.hasProperty("sdk_path")) {
+                def sdk_path = project.getProperties().getAt('sdk_path').toString()
+                for (arch in androidArchitectures) {
+                    def commandStr = 'cmake -G"Ninja" -DANDROID_ABI=' + arch + ' -DANDROID_NDK=' + sdk_path + '/ndk/22.0.7026061 -DCMAKE_BUILD_TYPE=Release -DCMAKE_MAKE_PROGRAM=' + sdk_path + '/cmake/3.10.2.4988404/bin/ninja -DCMAKE_TOOLCHAIN_FILE=' + sdk_path + '/ndk/22.0.7026061/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=23 -DANDROID_TOOLCHAIN=clang ../.. && ' +
+                            'cmake --build . --config Release && ' +
+                            'mv lib/Release/Android/ lib/Release/' + arch + ' && ' +
+                            'rm CMakeCache.txt'
+                    architectureCommandsMap.put(arch, 'cd build/natives && ' + commandStr)
+                }
+            } else if (OperatingSystem.current().isMacOsX()) {
+                architectureCommandsMap.put(architecture, 'cd build/natives && cmake ../.. && cmake --build . --config Release ' + buildConcurrency)
+            } else if (OperatingSystem.current().isLinux()) { // LINUX BUILD
+                def cmakeToolchain = ""
+                if (architecture == "aarch64" || architecture == "aarch32" || architecture == "x86" ||
+                        project.hasProperty("aarch64Build") || project.hasProperty("aarch32Build")) {
+                    cmakeToolchain = "-DCMAKE_TOOLCHAIN_FILE=../../linux-" + architecture + "-toolchain.cmake"
+                } else if (System.getProperty("os.arch") == "x86_64" || System.getProperty("os.arch") == "amd64") {
+                    cmakeToolchain = ""
+                }
+                architectureCommandsMap.put(architecture, 'cd build/natives && cmake ../.. ' + cmakeToolchain + ' && cmake --build . --config Release ' + buildConcurrency)
+            }
+        } else if (OperatingSystem.current().isWindows()) { // WINDOWS BUILD
+            architectureCommandsMap.put(architecture, 'cd build\\natives && cmake -A ' + generator + ' ..\\.. && cmake --build . --config Release')
+        }
+
+        architectureCommandsMap.each {arch, command ->
+            exec {
+                if (OperatingSystem.current().isLinux() ||
+                        OperatingSystem.current().isMacOsX() ||
+                        OperatingSystem.current().isUnix()) {
+                    commandLine 'sh', '-c', command
+                } else if (OperatingSystem.current().isWindows()) {
+                    commandLine "cmd", "/c", command
+                }
+            }
+            renamePlatformArtifactsDirectoryAccordingToArchitecture(nativeDir, arch)
+        }
+
+    }
+}
+
+def renamePlatformArtifactsDirectoryAccordingToArchitecture(File nativeDir, String architecture) {
+    def platformArtifactsDirectoryPath = ""
+    if (OperatingSystem.current().isLinux()) {
+        platformArtifactsDirectoryPath = "lib/Release/"
+        if (project.hasProperty("androidBuild") && project.hasProperty("sdk_path")) {
+            platformArtifactsDirectoryPath = platformArtifactsDirectoryPath + "Android"
+        } else {
+            platformArtifactsDirectoryPath = platformArtifactsDirectoryPath + "Linux"
+        }
+    } else if (OperatingSystem.current().isWindows()) {
+        platformArtifactsDirectoryPath = "bin/Release/Windows"
+    }
+
+    def platformArtifactsDirectory = new File(nativeDir, platformArtifactsDirectoryPath)
+
+    def architectureArtifactsDir = new File(platformArtifactsDirectory.getPath() + "-" + architecture)
+    if (architectureArtifactsDir.exists()) {
+        architectureArtifactsDir.deleteDir()
+    }
+
+    if (platformArtifactsDirectory.exists()) {
+        platformArtifactsDirectory.renameTo(architectureArtifactsDir)
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,14 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
 }
 version = '0.14.0-beta-2'
+
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}
+
 test {
     useJUnitPlatform()
+    systemProperty "file.encoding", "utf-8"
 }
 
 sourceSets {
@@ -100,8 +106,8 @@ task compileJNI {
     dependsOn compileJava
     outputs.upToDateWhen { false }
     doLast {
-
-        def nativeDir = new File('build/natives')
+        def nativeDir = new File(project.projectDir.toString() + '/build/natives')
+        System.out.println(nativeDir.getAbsolutePath())
         if (!nativeDir.exists()) {
             nativeDir.mkdirs()
         }
@@ -192,6 +198,9 @@ def renamePlatformArtifactsDirectoryAccordingToArchitecture(File nativeDir, Stri
         }
     } else if (OperatingSystem.current().isWindows()) {
         platformArtifactsDirectoryPath = "bin/Release/Windows"
+    } else {
+        // do not rename artifacts directory for OSes other than windows & linux
+        return
     }
 
     def platformArtifactsDirectory = new File(nativeDir, platformArtifactsDirectoryPath)

--- a/build.gradle
+++ b/build.gradle
@@ -189,10 +189,9 @@ def invokeMacOSBuild(File nativeDir, String architecture, String buildConcurrenc
 
 def invokeLinuxBuild(File nativeDir, String architecture, String buildConcurrency) {
     logger.info(String.format("Executing Linux build. Architecture: %s", architecture))
-    def isARMBuild = architecture == "aarch64" || architecture == "aarch32" || architecture == "x86" ||
-            project.hasProperty("aarch64Build") || project.hasProperty("aarch32Build")
+    def isCMakeToolchainFileRequired = architecture in ["aarch64", "aarch32", "x86"] || project.hasProperty("aarch64Build") || project.hasProperty("aarch32Build")
     def cmakeToolchain = ""
-    if (isARMBuild) {
+    if (isCMakeToolchainFileRequired) {
         cmakeToolchain = "-DCMAKE_TOOLCHAIN_FILE=./linux-" + architecture + "-toolchain.cmake"
     }
     exec {

--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,7 @@ task compileJNI {
         } else if (OperatingSystem.current().isLinux()) { // LINUX BUILD
             invokeLinuxBuild(nativeDir, architecture, buildConcurrency)
         } else if (OperatingSystem.current().isWindows()) { // WINDOWS BUILD
-            invokeWindowsBuild(nativeDir, architecture, buildConcurrency, generator)
+            invokeWindowsBuild(nativeDir, architecture, generator, buildConcurrency)
         } else {
             throw new GradleException(String.format("Operating System not supported: %s", OperatingSystem.current().getName()))
         }

--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ task compileJNI {
     outputs.upToDateWhen { false }
     doLast {
         def nativeDir = new File(project.projectDir.toString() + '/build/natives')
-        System.out.println(nativeDir.getAbsolutePath())
+
         if (!nativeDir.exists()) {
             nativeDir.mkdirs()
         }


### PR DESCRIPTION
- Add a flag to specify the parallel build level for C++/JNI code
- Delete build artifacts directory on rebuilding. (Right now the `mv` command fails because the renamed directory already exists. Deleting it on rebuilds fixes this issue.)